### PR TITLE
Bug fixed: variable used without initialization

### DIFF
--- a/solutions/dicegame/runner.py
+++ b/solutions/dicegame/runner.py
@@ -37,7 +37,6 @@ class GameRunner:
                 print("Congrats, you can add like a 5 year old...")
                 runner.wins += 1
                 count += 1
-                runner.consecutive_wins += 1
             else:
                 print("Sorry that's wrong")
                 print("The answer is: {}".format(runner.answer))


### PR DESCRIPTION
GameRunner class has no "consecutive_wins" variable but was used in the runner instance, and it causes a run-time error when answering the right sum.

Solved: delete the line containing "consecutive_wins" variable, so it runs well.