### PR TITLE
Fix consecutive-wins bug in solution

### DIFF
--- a/solutions/dicegame/runner.py
+++ b/solutions/dicegame/runner.py
@@ -1,4 +1,4 @@
-from .die import Die
+from .die import Die, roll
 from .utils import i_just_throw_an_exception
 
 class GameRunner:
@@ -21,11 +21,13 @@ class GameRunner:
 
     @classmethod
     def run(cls):
-        count = 0
+        consecutive_wins = 0
         runner = cls()
         while True:
 
             print("Round {}\n".format(runner.round))
+
+            roll(runner.dice)
 
             for die in runner.dice:
                 print(die.show())
@@ -36,18 +38,17 @@ class GameRunner:
             if guess == runner.answer:
                 print("Congrats, you can add like a 5 year old...")
                 runner.wins += 1
-                count += 1
-                runner.consecutive_wins += 1
+                consecutive_wins += 1
             else:
                 print("Sorry that's wrong")
                 print("The answer is: {}".format(runner.answer))
                 print("Like seriously, how could you mess that up")
                 runner.loses += 1
-                count = 0
+                consecutive_wins = 0
             print("Wins: {} Loses {}".format(runner.wins, runner.loses))
             runner.round += 1
 
-            if count == 6:
+            if consecutive_wins == 6:
                 print("You won... Congrats...")
                 print("The fact it took you so long is pretty sad")
                 break


### PR DESCRIPTION
## Problem

```python
runner.consecutive_wins += 1
```

`consecutive_wins` is never initialized.
The first time the player guesses correctly, the reference solution
crashes with:

`AttributeError: 'GameRunner' object has no attribute 'consecutive_wins'`


## Fix
- Track consecutive wins with a local consecutive_wins variable in
run() (initialized to 0), removing the broken instance attribute.
- Roll the dice each round so the game state actually changes between
rounds. (I'm not sure if not re-rolling is intentional — happy to revert this if so.)

